### PR TITLE
Documentation Update: Remove ES5 restriction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@
   your idea. This will avoid unnecessary work.
 
 The gopassbridge code must be fully reviewable also when installed as extension. 
-Therefore, no 3rd party libraries and plain ES5 must be used. Also keep your code as simple as possible. 
+Therefore, no 3rd party libraries and plain JavaScript must be used. Also keep your code as simple as possible. 
+
+Modern JavaScript features can be used if they are supported by newer versions of Chrome and Firefox.
 
 Also note in your pull request if you want the maintainer to prepare a new release of the Chrome and Firefox plugins.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@
 The gopassbridge code must be fully reviewable also when installed as extension. 
 Therefore, no 3rd party libraries and plain ES5 must be used. Also keep your code as simple as possible. 
 
-Also note in your pull request if you want the maintainer to prepare a new release of the chrome and firefox plugins.
+Also note in your pull request if you want the maintainer to prepare a new release of the Chrome and Firefox plugins.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # gopassbridge
 
-A web extension for firefox and chrome to insert login credentials from [gopass](https://github.com/justwatchcom/gopass)
+A web extension for Firefox and Chrome to insert login credentials from [gopass](https://github.com/justwatchcom/gopass)
 
 ## Summary
 
@@ -29,7 +29,7 @@ https://chrome.google.com/webstore/detail/gopass-bridge/kkhfnlkhiapbiehimabddjbi
 
 #### Build and install browser extension from source
 
-See `Makefile` release target. For firefox, the development plugin can be installed only temporarily while for chrome, the extracted extension can be installed permanently.
+See `Makefile` release target. For Firefox, the development plugin can be installed only temporarily while for Chrome, the extracted extension can be installed permanently.
 
 ### Connect to gopass
 
@@ -51,5 +51,5 @@ Contributions to this project are welcome!
 To start with development of this extension
 * clone the repo
 * run `yarn` to install the dependencies
-* run `make develop` to setup the development directories for firefox and chrome
-* run `make run-firefox` to start an empty firefox profile with the extension loaded and a debugger open
+* run `make develop` to setup the development directories for Firefox and Chrome
+* run `make run-firefox` to start an empty Firefox profile with the extension loaded and a debugger open


### PR DESCRIPTION
I updated the contributors documentation, as ES6 features were introduced in 6f3cf06c39d2b7f6f0b0c09511033771cd40e816.
This also allows for refactorings as described in #35.

I also tried to spell "Firefox" and "Chrome" consistently capitalised.