### PR TITLE
Update package.json and documentation for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,6 @@ To start with development of this extension
 * clone the repo
 * run `yarn` to install the dependencies
 * run `make develop` to setup the development directories for firefox and chrome
+* run `make package` to setup the release directories for Firefox and Chrome
+* run `yarn test` to run all unit tests, linters and auto-formatters
 * run `make run-firefox` to start an empty firefox profile with the extension loaded and a debugger open

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "gopassbridge",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Gopass Bridge allows searching and inserting login credentials from the gopass password manager",
-  "main": "index.js",
+  "main": "web-extension/gopassbridge.js",
   "scripts": {
     "test": "npm-run-all test:*",
     "test:lint": "npm run lint",
@@ -27,7 +27,8 @@
     "url": "https://github.com/martinhoefling/gopassbridge/issues"
   },
   "homepage": "https://github.com/martinhoefling/gopassbridge#readme",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "codecov": "^3.0.0",
     "eslint": "^4.16.0",
     "eslint-plugin-json": "^1.2.0",


### PR DESCRIPTION
I moved all dependencies to "devDependencies" (which they all actually are) to be more consistent with the "no 3rd party libraries" policy.