### PR TITLE
Fix errors when trying to click the submit button on login

### DIFF
--- a/tests/unit/content.test.js
+++ b/tests/unit/content.test.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 
 let heightMockReturn = 10;
 let widthMockReturn = 50;
-let clickCallback;
 
 global.getSyncStorage = () => null;
 
@@ -133,20 +132,25 @@ describe('on sample login form', () => {
     });
 
     describe('submit', () => {
+        function setupSubmitListener() {
+            const onClick = jest.fn();
+            const element = document.getElementById('submit');
+            element.addEventListener('click', onClick);
+            return onClick;
+        }
+
         beforeEach(() => {
             global.window.requestAnimationFrame = fn => {
                 fn();
             };
-            clickCallback = jest.fn();
             const form = document.getElementById('form');
             form.addEventListener('submit', e => {
                 e.preventDefault();
             });
-            const element = document.getElementById('submit');
-            element.addEventListener('click', clickCallback);
         });
 
-        test('is clicked whenonly one password field is present', () => {
+        test('is clicked when only one password field is present', () => {
+            const clickCallback = setupSubmitListener();
             content.processMessage({ type: 'TRY_LOGIN' });
             expect(clickCallback.mock.calls.length).toBe(1);
         });
@@ -159,19 +163,20 @@ describe('on sample login form', () => {
                     <input type='password' class='another-password'>
                     <input id='submit' type='submit'>
                 </form></body></html>`;
+            const clickCallback = setupSubmitListener();
             content.processMessage({ type: 'TRY_LOGIN' });
             expect(clickCallback.mock.calls.length).toBe(0);
         });
 
-        test('is not clicked when no form but submit in other form is present', () => {
+        test('is not clicked when password input is outside form, but submit in other form is present', () => {
             document.body.innerHTML = `
                 <html><body>
                     <input id='login' type='text' class='test-login'>
                     <input type='password' class='test-password'>
-                    <input type='password' class='another-password'>
-                <form id='form' action='/session' method='post'>                    
+                <form id='form' action='/unrelated' method='post'>                    
                     <input id='submit' type='submit'>
                 </form></body></html>`;
+            const clickCallback = setupSubmitListener();
             content.processMessage({ type: 'TRY_LOGIN' });
             expect(clickCallback.mock.calls.length).toBe(0);
         });

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -230,12 +230,10 @@ function tryLogIn() {
     } else {
         window.requestAnimationFrame(() => {
             if (passwortInputs.length === 1 && passwortInputs[0].form) {
-                selectFirstVisibleFormElement(passwortInputs[0].form, '[type=submit]').click();
-                return;
-            }
-            const submitButtons = selectVisibleElements('[type=submit]');
-            if (submitButtons.length) {
-                submitButtons[0].click();
+                const submitButton = selectFirstVisibleFormElement(passwortInputs[0].form, '[type=submit]');
+                if (submitButton) {
+                    submitButton.click();
+                }
             }
         });
     }


### PR DESCRIPTION
Improve fix #42 for #33 to not click on random submit buttons that are unrelated to the login.
For example on github.com this would randomly "click" the "Star/Unstar" button before.

Also fix error when trying to execute `.click()` on `null`, e.g. on union-investment.de this would throw:
`TypeError: selectFirstVisibleFormElement(...) is null`

The tests did not catch this, because `clickCallback` was setup incorrectly.