### PR TITLE
Support frame instead of iframe

### DIFF
--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -60,9 +60,13 @@ function isVisible(element) {
 
 function selectFocusedElement(parent) {
     parent = parent || document;
-    if (parent.body === parent.activeElement || parent.activeElement.tagName === 'IFRAME') {
+    if (
+        parent.body === parent.activeElement ||
+        parent.activeElement.tagName === 'IFRAME' ||
+        parent.activeElement.tagName === 'FRAME'
+    ) {
         let focusedElement = null;
-        parent.querySelectorAll('iframe').forEach(iframe => {
+        parent.querySelectorAll('iframe,frame').forEach(iframe => {
             if (iframe.src.startsWith(window.location.origin)) {
                 const focused = selectFocusedElement(iframe.contentWindow.document);
                 if (focused) {
@@ -85,7 +89,7 @@ function selectVisibleElements(selector) {
         }
     });
 
-    document.querySelectorAll('iframe').forEach(iframe => {
+    document.querySelectorAll('iframe,frame').forEach(iframe => {
         if (iframe.src.startsWith(window.location.origin)) {
             iframe.contentWindow.document.body.querySelectorAll(selector).forEach(element => {
                 if (isVisible(element)) {


### PR DESCRIPTION
Hi,

I am trying to get gopassbridge working with the website https://campus.tum.de.

The first issue I found is that some websites still use the deprecated <frameset>
and <frame> tags. Until they are not used anymore, we should still support those.

However, this PR doesn't fix the given website completely. While the login fields are
found and marked correctly now, the gopass popup immediately closes after opening.

I would appreciate any help with the second issue

Greetings,
veecue