### PR TITLE
Add basic auth support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 LOCAL_PRETTIER=node_modules/.bin/prettier
+LOCAL_WEB_EXT=node_modules/.bin/web-ext
 
 run-firefox: develop
-		web-ext run -v --browser-console -s $(CURDIR)/firefox
+		WEB_EXT_CMD=web-ext; if [ -e $(LOCAL_WEB_EXT) ]; then WEB_EXT_CMD=$(LOCAL_WEB_EXT); fi; \
+		$$WEB_EXT_CMD run -v --browser-console -s $(CURDIR)/firefox -u https://github.com/login
 
 develop: format
 		rm -rf chrome firefox

--- a/manifests/chrome-manifest-dev.json
+++ b/manifests/chrome-manifest-dev.json
@@ -34,7 +34,7 @@
       "i18n.js",
       "background.js"
     ],
-    "persistent": false
+    "persistent": true
   },
 
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0mHC1MVxHG3X9CZ6b6lp1hCW5j2nP9bRES/Mw6sL1Emkp6HyHXU745HRGv+JD8Q+jvo85IYjGnxrcrgq+K9Op8S4ggzjaZMVL9kmDeluQPRE4247uEu2WCLZR7x00A2unZtErvlwNYiYIRcqhDZ5VQDtxKNdg6CsFr56g7ur2iuF4+RwKSDbdfVY0t9yb++Rsj9aAtarDbPnuR4gWDzR/3AL4SmgU21BQYARjUQHLFmmH1M2YWVz2I9Z3w2m3EfL6oNMSm7qFweRTrBMmVKLwQ9jitvz8To7QX5si6y8L3CRKBNtBIwBF3t8Cm4CIB5Tfjh/6RN5cf/9D7Jci0EXOQIDAQAB",
@@ -69,6 +69,8 @@
     "nativeMessaging",
     "http://*/*",
     "https://*/*",
-    "notifications"
+    "notifications",
+    "webRequest",
+    "webRequestBlocking"
   ]
 }

--- a/manifests/chrome-manifest.json
+++ b/manifests/chrome-manifest.json
@@ -34,7 +34,7 @@
       "i18n.js",
       "background.js"
     ],
-    "persistent": false
+    "persistent": true
   },
 
   "options_ui": {
@@ -67,6 +67,8 @@
     "nativeMessaging",
     "http://*/*",
     "https://*/*",
-    "notifications"
+    "notifications",
+    "webRequest",
+    "webRequestBlocking"
   ]
 }

--- a/manifests/firefox-manifest.json
+++ b/manifests/firefox-manifest.json
@@ -75,6 +75,8 @@
     "clipboardWrite",
     "storage",
     "nativeMessaging",
-    "notifications"
+    "notifications",
+    "webRequest",
+    "webRequestBlocking"
   ]
 }

--- a/tests/unit/background.test.js
+++ b/tests/unit/background.test.js
@@ -5,9 +5,7 @@ jest.useFakeTimers();
 global.showNotificationOnSetting = jest.fn();
 global.sendNativeAppMessage = jest.fn();
 global.browser.extension = {
-    getViews: jest.fn(() => {
-        return { length: 0 };
-    }),
+    getViews: jest.fn(() => ({ length: 0 })),
 };
 global.urlDomain = jest.fn(() => 'some.url');
 global.i18n = {
@@ -192,6 +190,213 @@ describe('background', () => {
                         expect(global.browser.tabs.sendMessage.mock.calls[1]).toEqual([42, { type: 'TRY_LOGIN' }]);
                     });
                 });
+            });
+        });
+    });
+
+    describe('onAuthRequired', () => {
+        const authUrl = 'https://example.com';
+        const validAuthPopupUrl = `http://localhost/?authUrl=${encodeURIComponent(authUrl)}`;
+        const invalidAuthPopupUrl = `http://localhost.evil/?authUrl=${encodeURIComponent(authUrl)}`;
+
+        let onAuthRequiredCallback, windowCreatePromise;
+
+        beforeEach(() => {
+            global.browser.extension.getViews.mockReset();
+            global.browser.extension.getViews.mockReturnValue({ length: 0 });
+            global.getPopupUrl = jest.fn(() => 'http://localhost/');
+            global.executeOnSetting = jest.fn((_, enabled, disabled) => enabled());
+            windowCreatePromise = Promise.resolve({ id: 42 });
+            global.browser.windows = {
+                create: jest.fn(() => windowCreatePromise),
+                onRemoved: { addListener: jest.fn(), removeListener: jest.fn() },
+            };
+            onAuthRequiredCallback = browser.webRequest.onAuthRequired.addListener.mock.calls[0][0];
+            global.sendNativeAppMessage.mockResolvedValue({ username: 'some.url', password: 'waldfee' });
+        });
+
+        test('opens auth popup and resolves auth request successfully with login credentials', () => {
+            expect.assertions(5);
+
+            const authRequiredPromise = onAuthRequiredCallback({ url: authUrl });
+
+            return windowCreatePromise.then(() => {
+                const processMessagePromise = background.processMessageAndCatch(
+                    { type: 'LOGIN_TAB', entry: 'some/entry' },
+                    { tab: {}, url: validAuthPopupUrl }
+                );
+
+                return Promise.all([authRequiredPromise, processMessagePromise]).then(([authRequiredResult, _]) => {
+                    expect(browser.windows.create.mock.calls.length).toBe(1);
+                    expect(browser.windows.onRemoved.addListener.mock.calls).toEqual(
+                        browser.windows.onRemoved.removeListener.mock.calls
+                    );
+                    expect(global.sendNativeAppMessage.mock.calls).toEqual([
+                        [{ type: 'getLogin', entry: 'some/entry' }],
+                    ]);
+                    expect(global.showNotificationOnSetting.mock.calls.length).toEqual(0);
+                    expect(authRequiredResult).toEqual({
+                        authCredentials: { username: 'some.url', password: 'waldfee' },
+                    });
+                });
+            });
+        });
+
+        test('opens auth popup but when popup is closed falls back to browser auth dialog', () => {
+            expect.assertions(5);
+
+            const authRequiredPromise = onAuthRequiredCallback({ url: authUrl });
+
+            return windowCreatePromise.then(() => {
+                browser.windows.onRemoved.addListener.mock.calls[0][0](42);
+
+                return authRequiredPromise.then(authRequiredResult => {
+                    expect(browser.windows.create.mock.calls.length).toBe(1);
+                    expect(browser.windows.onRemoved.addListener.mock.calls).toEqual(
+                        browser.windows.onRemoved.removeListener.mock.calls
+                    );
+                    expect(global.sendNativeAppMessage.mock.calls.length).toBe(0);
+                    expect(global.showNotificationOnSetting.mock.calls.length).toEqual(0);
+                    expect(authRequiredResult).toEqual({ cancel: false });
+                });
+            });
+        });
+
+        test('opens auth popup but does not resolve auth request after native app error', () => {
+            expect.assertions(6);
+
+            global.sendNativeAppMessage.mockResolvedValueOnce({ error: 'native app broken' });
+
+            const authRequiredPromise = onAuthRequiredCallback({ url: authUrl });
+
+            return windowCreatePromise.then(() => {
+                const processMessagePromise = background.processMessageAndCatch(
+                    { type: 'LOGIN_TAB', entry: 'some/entry' },
+                    { tab: {}, url: validAuthPopupUrl }
+                );
+
+                return Promise.all([authRequiredPromise, processMessagePromise]).then(null, processMessageError => {
+                    expect(browser.windows.create.mock.calls.length).toBe(1);
+                    expect(browser.windows.onRemoved.addListener.mock.calls.length).toBe(1);
+                    expect(browser.windows.onRemoved.removeListener.mock.calls.length).toBe(0); // popup still open
+                    expect(global.sendNativeAppMessage.mock.calls).toEqual([
+                        [{ type: 'getLogin', entry: 'some/entry' }],
+                    ]);
+                    expect(global.showNotificationOnSetting.mock.calls.length).toEqual(0);
+                    expect(processMessageError.message).toEqual('native app broken');
+
+                    return background.processMessageAndCatch(
+                        // Cleanup remaining popup
+                        { type: 'LOGIN_TAB', entry: 'some/entry' },
+                        { tab: {}, url: validAuthPopupUrl }
+                    );
+                });
+            });
+        });
+
+        test('opens auth popup but does not resolve auth request after URL mismatch', () => {
+            expect.assertions(6);
+
+            spyOn(global.console, 'warn');
+
+            const authRequiredPromise = onAuthRequiredCallback({ url: authUrl });
+
+            return windowCreatePromise.then(() => {
+                return background
+                    .processMessageAndCatch(
+                        { type: 'LOGIN_TAB', entry: 'some/entry' },
+                        { tab: {}, url: invalidAuthPopupUrl }
+                    )
+                    .then(() => {
+                        expect(browser.windows.create.mock.calls.length).toBe(1);
+                        expect(browser.windows.onRemoved.addListener.mock.calls.length).toBe(1);
+                        expect(browser.windows.onRemoved.removeListener.mock.calls.length).toBe(0); // popup still open
+                        expect(global.sendNativeAppMessage.mock.calls.length).toBe(1);
+                        expect(global.showNotificationOnSetting.mock.calls.length).toEqual(0);
+                        expect(global.console.warn.calls.allArgs()).toEqual([
+                            [
+                                'Could not resolve auth request due to URL mismatch',
+                                validAuthPopupUrl,
+                                invalidAuthPopupUrl,
+                            ],
+                        ]);
+
+                        const cleanupPopupPromise = background.processMessageAndCatch(
+                            { type: 'LOGIN_TAB', entry: 'some/entry' },
+                            { tab: {}, url: validAuthPopupUrl }
+                        );
+                        return Promise.all([authRequiredPromise, cleanupPopupPromise]);
+                    });
+            });
+        });
+
+        test('does not open auth popup when setting is disabled', () => {
+            expect.assertions(6);
+
+            global.executeOnSetting = jest.fn((_, enabled, disabled) => disabled());
+
+            return onAuthRequiredCallback({ url: authUrl }).then(authRequiredResult => {
+                expect(browser.windows.create.mock.calls.length).toBe(0);
+                expect(browser.windows.onRemoved.addListener.mock.calls.length).toBe(0);
+                expect(browser.windows.onRemoved.removeListener.mock.calls.length).toBe(0);
+                expect(global.sendNativeAppMessage.mock.calls.length).toBe(0);
+                expect(authRequiredResult).toEqual({});
+                expect(global.showNotificationOnSetting.mock.calls.length).toEqual(0);
+            });
+        });
+
+        test('does not open multiple auth popups at the same time', () => {
+            expect.assertions(6);
+
+            const firstAuthRequiredPromise = onAuthRequiredCallback({ url: authUrl });
+            return windowCreatePromise.then(() => {
+                const secondAuthRequiredPromise = onAuthRequiredCallback({ url: authUrl });
+                const processMessagePromise = background.processMessageAndCatch(
+                    { type: 'LOGIN_TAB', entry: 'some/entry' },
+                    { tab: {}, url: validAuthPopupUrl }
+                );
+
+                return Promise.all([firstAuthRequiredPromise, secondAuthRequiredPromise, processMessagePromise]).then(
+                    ([firstAuthRequiredResult, secondAuthRequiredResult, _]) => {
+                        expect(browser.windows.create.mock.calls.length).toBe(1);
+                        expect(browser.windows.onRemoved.addListener.mock.calls).toEqual(
+                            browser.windows.onRemoved.removeListener.mock.calls
+                        );
+                        expect(global.sendNativeAppMessage.mock.calls).toEqual([
+                            [{ type: 'getLogin', entry: 'some/entry' }],
+                        ]);
+                        expect(firstAuthRequiredResult).toEqual({
+                            authCredentials: { username: 'some.url', password: 'waldfee' },
+                        });
+                        expect(secondAuthRequiredResult).toEqual({});
+                        expect(global.showNotificationOnSetting.mock.calls).toEqual([
+                            ['__i18n_cannotHandleMultipleAuthRequests__'],
+                        ]);
+                    }
+                );
+            });
+        });
+
+        test('does not resolve auth request when no request is pending', () => {
+            expect.assertions(6);
+
+            spyOn(global.console, 'warn');
+
+            const url = validAuthPopupUrl;
+            const processMessagePromise = background.processMessageAndCatch(
+                { type: 'LOGIN_TAB', entry: 'some/entry' },
+                { tab: {}, url }
+            );
+
+            return processMessagePromise.then(() => {
+                expect(browser.windows.create.mock.calls.length).toBe(0);
+                expect(browser.windows.onRemoved.addListener.mock.calls.length).toBe(0);
+                expect(browser.windows.onRemoved.removeListener.mock.calls.length).toBe(0);
+                expect(global.sendNativeAppMessage.mock.calls).toEqual([[{ type: 'getLogin', entry: 'some/entry' }]]);
+                expect(global.showNotificationOnSetting.mock.calls.length).toEqual(0);
+                expect(global.console.warn.calls.allArgs()).toEqual([
+                    ['Tried to resolve auth request, but no auth request is currently pending.', url],
+                ]);
             });
         });
     });

--- a/tests/unit/create.test.js
+++ b/tests/unit/create.test.js
@@ -10,7 +10,7 @@ global.setStatusText = jest.fn();
 global.urlDomain = jest.fn(() => 'some.domain');
 global.searchHost = jest.fn();
 global.logAndDisplayError = jest.fn();
-global.currentTab = { url: 'http://some.domain' };
+global.currentPageUrl = 'http://some.domain';
 global.searchTerm = '';
 global.i18n = {
     getMessage: jest.fn(key => {

--- a/tests/unit/details.test.js
+++ b/tests/unit/details.test.js
@@ -10,7 +10,8 @@ global.sendNativeAppMessage = jest.fn();
 global.getLocalStorageKey = jest.fn();
 global.setLocalStorageKey = jest.fn();
 global.urlDomain = jest.fn(() => 'some.domain');
-global.currentTab = { url: 'http://other.domain', id: 42 };
+global.currentTabId = 42;
+global.currentPageUrl = 'http://other.domain';
 global.re_weburl = new RegExp('https://.*');
 global.logAndDisplayError = jest.fn();
 

--- a/tests/unit/generic.test.js
+++ b/tests/unit/generic.test.js
@@ -172,3 +172,25 @@ describe('showNotificationOnSetting', () => {
         });
     });
 });
+
+describe('getPopupUrl', () => {
+    beforeEach(() => {
+        global.browser.runtime.getURL = jest.fn(() => 'some-popup');
+    });
+
+    test('returns URL', () => {
+        expect(generic.getPopupUrl()).toBe('some-popup');
+    });
+});
+
+describe('isChrome', () => {
+    test('for Chrome', () => {
+        global.browser.runtime.getURL = jest.fn(() => 'chrome-extension://kkhfnlkhiapbiehimabddjbimfaijdhk/');
+        expect(generic.isChrome()).toBe(true);
+    });
+
+    test('for Firefox', () => {
+        global.browser.runtime.getURL = jest.fn(() => 'moz-extension://eec37db0-22ad-4bf1-9068-5ae08df8c7e9/');
+        expect(generic.isChrome()).toBe(false);
+    });
+});

--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -7,7 +7,7 @@ global.logError = jest.fn();
 global.getSettings = jest.fn();
 global.getSettings.mockResolvedValue({ defaultfolder: 'myfolder' });
 global.urlDomain = jest.fn(() => 'some.domain');
-global.currentTab = { url: 'http://some.domain' };
+global.currentPageUrl = 'http://some.domain';
 
 require('popup.js');
 

--- a/tests/unit/search.test.js
+++ b/tests/unit/search.test.js
@@ -36,7 +36,9 @@ const search = window.tests.search;
 function resetSearchState() {
     document.body.innerHTML = documentHtml;
     jest.clearAllMocks();
-    global.currentTab = { id: 42, url: 'http://some.host' };
+    global.currentTabId = 42;
+    global.currentPageUrl = 'http://some.host';
+    global.currentTabFavIconUrl = null;
 }
 
 describe('search method', () => {
@@ -233,7 +235,7 @@ describe('search method', () => {
         });
 
         test('break if tab has changed', () => {
-            global.currentTab.url = 'http://evil.host';
+            global.currentPageUrl = 'http://evil.host';
             global.searchedUrl = 'muh';
             search._onSearchResults([], false);
             expect(global.createButtonWithCallback.mock.calls.length).toBe(0);
@@ -241,7 +243,7 @@ describe('search method', () => {
 
         describe('favicon', () => {
             beforeEach(() => {
-                global.currentTab.favIconUrl = 'http://some.host/fav.ico';
+                global.currentTabFavIconUrl = 'http://some.host/fav.ico';
             });
 
             test('sets favicon if matching', () => {

--- a/web-extension/_locales/de/messages.json
+++ b/web-extension/_locales/de/messages.json
@@ -19,6 +19,14 @@
     "message": "Benutzername konnte nicht bestimmt werden",
     "description": "shown when no username in response does not match current domain"
   },
+  "authLoginDescription": {
+    "message": "Eintrag auswählen zur Authentifizierung mit",
+    "description": "description on basic auth login popup, url will be appended"
+  },
+  "authLoginOptionsInfo": {
+    "message": "(kann in den Einstellungen der Browser-Erweiterung deaktiviert werden)",
+    "description": "info that basic auth handling can be disabled in options"
+  },
   "searchPlaceholder": {
     "message": "tippen um zu suchen...",
     "description": "placeholder in search field"
@@ -112,6 +120,10 @@
     "message": "Einloggen wenn Logindaten ausgefüllt wurden",
     "description": "label of login after fill checkbox"
   },
+  "optionsHandleAuthRequestsLabel": {
+    "message": "Logindaten für HTTP-Basic-Authentifizierung zur Verfügung stellen",
+    "description": "label of handle auth requests checkbox"
+  },
   "optionsDefaultFolderLabel": {
     "message": "Standardordner für neue Logins",
     "description": "label of default folder"
@@ -127,5 +139,9 @@
   "noURLInEntry": {
     "message": "Eintrag hat kein URL Attribut",
     "description": "Shown when no url attribute in entry and page is loaded"
+  },
+  "cannotHandleMultipleAuthRequests": {
+    "message": "Vorherige Authentifizierung ist noch nicht abgeschlossen, bitte alle Popups schließen und erneut versuchen.",
+    "description": "Error when another basic authentication popup is already open"
   }
 }

--- a/web-extension/_locales/en/messages.json
+++ b/web-extension/_locales/en/messages.json
@@ -19,6 +19,14 @@
     "message": "could not determine username",
     "description": "shown when no username in response does not match current domain"
   },
+  "authLoginDescription": {
+    "message": "Select credentials to authenticate with",
+    "description": "description on basic auth login popup, url will be appended"
+  },
+  "authLoginOptionsInfo": {
+    "message": "(this can be disabled in the browser extension options)",
+    "description": "info that basic auth handling can be disabled in options"
+  },
   "searchPlaceholder": {
     "message": "start typing to search...",
     "description": "placeholder in search field"
@@ -112,6 +120,10 @@
     "message": "Login after filling in credentials",
     "description": "label of login after fill checkbox"
   },
+  "optionsHandleAuthRequestsLabel": {
+    "message": "Provide credentials for basic auth requests",
+    "description": "label of handle auth requests checkbox"
+  },
   "optionsDefaultFolderLabel": {
     "message": "Default folder for new credentials",
     "description": "label of default folder"
@@ -127,5 +139,9 @@
   "noURLInEntry": {
     "message": "Entry has no url attribute",
     "description": "Shown when no url attribute in entry and page is loaded"
+  },
+  "cannotHandleMultipleAuthRequests": {
+    "message": "Previous authentication is still in progress, please close all popups and try again.",
+    "description": "Error when another basic authentication popup is already open"
   }
 }

--- a/web-extension/create.js
+++ b/web-extension/create.js
@@ -48,7 +48,7 @@ function onCreateResult(response) {
         return;
     }
     console.log('created');
-    searchTerm = urlDomain(currentTab.url);
+    searchTerm = urlDomain(currentPageUrl);
     searchHost(searchTerm);
 }
 

--- a/web-extension/details.js
+++ b/web-extension/details.js
@@ -8,13 +8,13 @@ function onEntryData(element, message) {
         }
         oldDetailView.remove();
     });
-    return browser.storage.local.remove(LAST_DETAIL_VIEW_PREFIX + urlDomain(currentTab.url)).then(() => {
+    return browser.storage.local.remove(LAST_DETAIL_VIEW_PREFIX + urlDomain(currentPageUrl)).then(() => {
         if (alreadyShown) return;
 
         const newDetailView = _detailViewFromMessage(message);
         newDetailView.classList.add('detail-view');
         _insertAfter(newDetailView, element);
-        setLocalStorageKey(LAST_DETAIL_VIEW_PREFIX + urlDomain(currentTab.url), element.innerText);
+        setLocalStorageKey(LAST_DETAIL_VIEW_PREFIX + urlDomain(currentPageUrl), element.innerText);
     });
 }
 
@@ -91,7 +91,7 @@ function _openURL(event) {
 
 function restoreDetailView() {
     let element;
-    return getLocalStorageKey(LAST_DETAIL_VIEW_PREFIX + urlDomain(currentTab.url)).then(value => {
+    return getLocalStorageKey(LAST_DETAIL_VIEW_PREFIX + urlDomain(currentPageUrl)).then(value => {
         if (!value) return Promise.resolve();
 
         Array.from(document.getElementsByClassName('login')).forEach(loginElement => {

--- a/web-extension/generic.js
+++ b/web-extension/generic.js
@@ -78,11 +78,11 @@ function showNotificationOnSetting(message) {
 }
 
 function getPopupUrl() {
-    return browser.extension.getURL('gopassbridge.html');
+    return browser.runtime.getURL('gopassbridge.html');
 }
 
 function isChrome() {
-    return browser.extension.getURL('/').startsWith('chrome');
+    return browser.runtime.getURL('/').startsWith('chrome');
 }
 
 window.tests = {
@@ -94,5 +94,7 @@ window.tests = {
         getLocalStorageKey,
         createButtonWithCallback,
         showNotificationOnSetting,
+        getPopupUrl,
+        isChrome,
     },
 };

--- a/web-extension/generic.js
+++ b/web-extension/generic.js
@@ -4,6 +4,7 @@ const DEFAULT_SETTINGS = {
     markfields: true,
     sendnotifications: true,
     submitafterfill: true,
+    handleauthrequests: true,
     defaultfolder: 'Account',
 };
 
@@ -74,6 +75,14 @@ function showNotificationOnSetting(message) {
             message: message,
         });
     });
+}
+
+function getPopupUrl() {
+    return browser.extension.getURL('gopassbridge.html');
+}
+
+function isChrome() {
+    return browser.extension.getURL('/').startsWith('chrome');
 }
 
 window.tests = {

--- a/web-extension/gopassbridge.html
+++ b/web-extension/gopassbridge.html
@@ -9,6 +9,11 @@
 <div class="container">
     <div id="hidden_clipboard"></div>
     <div id="content">
+        <div id="auth_login" style="display: none;">
+            __MSG_authLoginDescription__<br>
+            <span id="auth_login_url">(?)</span><br>
+            <span id="auth_login_options_info">__MSG_authLoginOptionsInfo__</span>
+        </div>
         <div class="search" style="display: block;">
             <form>
                 <input id="search_input" placeholder="__MSG_searchPlaceholder__" autocomplete="off" autofocus

--- a/web-extension/gopassbridge.js
+++ b/web-extension/gopassbridge.js
@@ -10,7 +10,7 @@ browser.tabs.onActivated.addListener(switchTab);
 
 function switchTab(tab) {
     console.log('Switching to tab', tab);
-    if (tab) {
+    if (tab && tab.url && tab.id) {
         currentTabId = tab.id;
         currentTabFavIconUrl = tab.favIconUrl;
     }
@@ -55,8 +55,6 @@ function _handleUrlSearch(url) {
 window.tests = {
     gopassbridge: {
         switchTab,
-        getCurrentTab: () => {
-            return currentTab;
-        },
+        getCurrentTab: () => ({ currentPageUrl, currentTabId, currentTabFavIconUrl }),
     },
 };

--- a/web-extension/gopassbridge.js
+++ b/web-extension/gopassbridge.js
@@ -1,32 +1,55 @@
 'use strict';
 
-let currentTab;
+let currentPageUrl;
+let currentTabId;
+let currentTabFavIconUrl;
 
 browser.tabs.query({ currentWindow: true, active: true }).then(tabs => switchTab(tabs[0]));
 
 browser.tabs.onActivated.addListener(switchTab);
 
 function switchTab(tab) {
-    console.log('Switching to tab ' + tab.url);
-    if (tab && tab.url && tab.id) {
-        currentTab = tab;
-        executeOnSetting('markfields', () => {
-            browser.tabs.sendMessage(currentTab.id, { type: 'MARK_LOGIN_FIELDS' });
-        });
-        const tabUrl = urlDomain(currentTab.url);
-        if (tabUrl) {
-            return getLocalStorageKey(LAST_DOMAIN_SEARCH_PREFIX + tabUrl).then(value => {
-                if (value) {
-                    return search(value).then(restoreDetailView);
-                } else {
-                    return searchHost(tabUrl).then(restoreDetailView);
-                }
-            });
-        } else {
-            document.getElementById('results').innerHTML = '';
+    console.log('Switching to tab', tab);
+    if (tab) {
+        currentTabId = tab.id;
+        currentTabFavIconUrl = tab.favIconUrl;
+    }
+
+    if (window && window.location.origin + window.location.pathname === getPopupUrl()) {
+        const authUrlEncoded = new URLSearchParams(window.location.search).get('authUrl');
+        if (authUrlEncoded) {
+            const authUrl = decodeURIComponent(authUrlEncoded);
+            document.getElementById('auth_login').style.display = 'block';
+            document.getElementById('auth_login_url').textContent = authUrl;
+            return _handleUrlSearch(authUrl);
         }
     }
+
+    if (tab && tab.url && tab.id) {
+        executeOnSetting('markfields', () => {
+            browser.tabs.sendMessage(currentTabId, { type: 'MARK_LOGIN_FIELDS' });
+        });
+        return _handleUrlSearch(tab.url);
+    }
+
     return Promise.resolve();
+}
+
+function _handleUrlSearch(url) {
+    currentPageUrl = url;
+
+    const searchUrl = urlDomain(url);
+    if (searchUrl) {
+        return getLocalStorageKey(LAST_DOMAIN_SEARCH_PREFIX + searchUrl).then(value => {
+            if (value) {
+                return search(value).then(restoreDetailView);
+            } else {
+                return searchHost(searchUrl).then(restoreDetailView);
+            }
+        });
+    } else {
+        document.getElementById('results').innerHTML = '';
+    }
 }
 
 window.tests = {

--- a/web-extension/gopassbridge.js
+++ b/web-extension/gopassbridge.js
@@ -10,22 +10,22 @@ browser.tabs.onActivated.addListener(switchTab);
 
 function switchTab(tab) {
     console.log('Switching to tab', tab);
-    if (tab && tab.url && tab.id) {
+
+    const isContentTab = tab && tab.url && tab.id;
+
+    if (isContentTab) {
         currentTabId = tab.id;
         currentTabFavIconUrl = tab.favIconUrl;
     }
 
-    if (window && window.location.origin + window.location.pathname === getPopupUrl()) {
-        const authUrlEncoded = new URLSearchParams(window.location.search).get('authUrl');
-        if (authUrlEncoded) {
-            const authUrl = decodeURIComponent(authUrlEncoded);
-            document.getElementById('auth_login').style.display = 'block';
-            document.getElementById('auth_login_url').textContent = authUrl;
-            return _handleUrlSearch(authUrl);
-        }
+    const authUrl = _parseAuthUrl();
+    if (authUrl) {
+        document.getElementById('auth_login').style.display = 'block';
+        document.getElementById('auth_login_url').textContent = authUrl;
+        return _handleUrlSearch(authUrl);
     }
 
-    if (tab && tab.url && tab.id) {
+    if (isContentTab) {
         executeOnSetting('markfields', () => {
             browser.tabs.sendMessage(currentTabId, { type: 'MARK_LOGIN_FIELDS' });
         });
@@ -33,6 +33,16 @@ function switchTab(tab) {
     }
 
     return Promise.resolve();
+}
+
+function _parseAuthUrl() {
+    if (window && window.location.origin + window.location.pathname === getPopupUrl()) {
+        const authUrlEncoded = new URLSearchParams(window.location.search).get('authUrl');
+        if (authUrlEncoded) {
+            return decodeURIComponent(authUrlEncoded);
+        }
+    }
+    return null;
 }
 
 function _handleUrlSearch(url) {

--- a/web-extension/options.html
+++ b/web-extension/options.html
@@ -19,6 +19,7 @@
     <label><input type="checkbox" id="markfields"/> __MSG_optionsMarkFieldsLabel__</label>
     <label><input type="checkbox" id="sendnotifications"/> __MSG_optionsSendNotificationsLabel__</label>
     <label><input type="checkbox" id="submitafterfill"/> __MSG_optionsLoginAfterFillLabel__</label>
+    <label><input type="checkbox" id="handleauthrequests"/> __MSG_optionsHandleAuthRequestsLabel__</label>
     <label>__MSG_optionsDefaultFolderLabel__ <input type="text" id="defaultfolder"/></label>
     <button type="button" id="clear">__MSG_optionsResetButtonText__</button>
 </div>

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -23,7 +23,7 @@ function switchToCreateNewDialog() {
         document.getElementsByClassName('search')[0].style.display = 'none';
         document.getElementsByClassName('results')[0].style.display = 'none';
         document.getElementsByClassName('create')[0].style.display = 'block';
-        document.getElementById('create_name').value = `${settings['defaultfolder']}/${urlDomain(currentTab.url)}`;
+        document.getElementById('create_name').value = `${settings['defaultfolder']}/${urlDomain(currentPageUrl)}`;
         document.getElementById('create_docreate').style.display = 'block';
         document.getElementById('create_doabort').style.display = 'block';
         document.getElementById('creating').style.display = 'none';

--- a/web-extension/search.js
+++ b/web-extension/search.js
@@ -28,7 +28,7 @@ function _onSearchInputEvent() {
     if (input.value.length) {
         search(input.value);
     } else {
-        const currentHost = urlDomain(currentTab.url);
+        const currentHost = urlDomain(currentPageUrl);
         searchHost(currentHost);
     }
 }
@@ -62,7 +62,7 @@ function _doSearch(term, queryHost) {
 
     searchTerm = term;
     armSpinnerTimeout();
-    searchedUrl = currentTab.url;
+    searchedUrl = currentPageUrl;
     searching = new Promise((resolve, reject) => {
         const message = {
             type: queryHost ? 'queryHost' : 'query',
@@ -91,8 +91,8 @@ function searchHost(host) {
 }
 
 function _faviconUrl() {
-    if (currentTab && currentTab.favIconUrl && currentTab.favIconUrl.indexOf(urlDomain(currentTab.url)) > -1) {
-        return currentTab.favIconUrl;
+    if (currentTabFavIconUrl && currentTabFavIconUrl.indexOf(urlDomain(currentPageUrl)) > -1) {
+        return currentTabFavIconUrl;
     }
 
     return 'icons/si-glyph-key-2.svg';
@@ -131,16 +131,16 @@ function _onSearchResults(response, isHostQuery) {
     try {
         if (response.error) {
             setStatusText(response.error);
-        } else if (currentTab.url !== searchedUrl) {
+        } else if (currentPageUrl !== searchedUrl) {
             console.log('Result is not from the same URL as we were searching for, ignoring');
         } else if (response.length) {
             setLocalStorageKey(
-                LAST_DOMAIN_SEARCH_PREFIX + urlDomain(currentTab.url),
+                LAST_DOMAIN_SEARCH_PREFIX + urlDomain(currentPageUrl),
                 document.getElementById('search_input').value
             );
             _displaySearchResults(response, isHostQuery);
         } else {
-            browser.storage.local.remove(LAST_DOMAIN_SEARCH_PREFIX + urlDomain(currentTab.url));
+            browser.storage.local.remove(LAST_DOMAIN_SEARCH_PREFIX + urlDomain(currentPageUrl));
             _displayNoResults();
         }
     } finally {
@@ -160,7 +160,7 @@ function _onEntryAction(event, element) {
     } else {
         const value = (element || event.target).innerText;
         browser.runtime
-            .sendMessage({ type: 'LOGIN_TAB', entry: value, tab: { id: currentTab.id, url: currentTab.url } })
+            .sendMessage({ type: 'LOGIN_TAB', entry: value, tab: { id: currentTabId, url: currentPageUrl } })
             .then(_onLoginCredentialsDidLogin, logAndDisplayError);
     }
 }

--- a/web-extension/styles.css
+++ b/web-extension/styles.css
@@ -250,3 +250,19 @@ body {
     outline: 0;
     background-color: #ff8080;
 }
+
+#auth_login {
+    padding: 10px;
+    background-color: #6bd6e4;
+    font-size: 14px;
+    line-height: 1.2;
+}
+
+#auth_login_url {
+    font-weight: bold;
+}
+
+#auth_login_options_info {
+    font-size: 12px;
+    font-style: italic;
+}


### PR DESCRIPTION
This adds support for request authentication as requested in #89 and #91 using https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired.

A small workaround was required to support Chrome, see https://github.com/mozilla/webextension-polyfill/issues/91.

Some manual test cases:
- Opening multiple basic auth sessions (e.g. with https://httpbin.org/basic-auth/user/password1, https://httpbin.org/basic-auth/user/password2) should only open a gopassbridge popup for the first auth request and the native browser auth dialog for any other auth requests, as long as another gopassbridge popup is still open. This is done to simplify the implementation.
- Disabling the basic-auth setting in options should show the native browser auth dialog when disabled and switching back to gopassbridge for the next auth request when reenabled.
- Closing the gopassbridge auth popup window without selecting any credentials should open the browser native auth dialog.
- Selecting invalid credentials in gopassbridge should reopen a new gopassbridge popup window (this is the same behaviour as the native browser auth dialog)
- Any errors in the native messaging between the popup and gopass should keep the popup open and show the error messages, until the window is either closed or some credentials are selected.