### PR TITLE
Set required browser versions to sane defaults

### DIFF
--- a/manifests/chrome-manifest.json
+++ b/manifests/chrome-manifest.json
@@ -27,6 +27,8 @@
     }
   ],
 
+  "minimum_chrome_version": "63",
+
   "background": {
     "scripts": [
       "vendor/browser-polyfill.js",

--- a/manifests/firefox-manifest.json
+++ b/manifests/firefox-manifest.json
@@ -17,7 +17,7 @@
   "applications": {
     "gecko": {
       "id": "{eec37db0-22ad-4bf1-9068-5ae08df8c7e9}",
-      "strict_min_version": "45.0"
+      "strict_min_version": "60.0"
     }
   },
 


### PR DESCRIPTION
Firefox is set to latest ESR and chrome to a 1yr old version. We may need to update this from time as used features, like onAuth are not supported by every browser version.