### PR TITLE
fix for browser crash when jsonapi not configured, closes #104

### DIFF
--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -104,14 +104,18 @@ describe('popup', () => {
 
     describe('logAndDisplayError', () => {
         test('displays message', () => {
-            popup.logAndDisplayError({ message: 'sample error messsage' });
+            expect(() => {
+                popup.logAndDisplayError({ message: 'sample error messsage' });
+            }).toThrow({ message: 'sample error messsage' });
             expect(document.getElementsByClassName('status-text')[0].innerHTML).toBe('sample error messsage');
         });
 
         test('switches back to search', () => {
-            expect.assertions(3);
+            expect.assertions(4);
             return popup.switchToCreateNewDialog().then(() => {
-                popup.logAndDisplayError({ message: 'sample error messsage' });
+                expect(() => {
+                    popup.logAndDisplayError({ message: 'sample error messsage' });
+                }).toThrow({ message: 'sample error messsage' });
                 expect(document.getElementsByClassName('search')[0].style.display).toBe('block');
                 expect(document.getElementsByClassName('results')[0].style.display).toBe('block');
                 expect(document.getElementsByClassName('create')[0].style.display).toBe('none');

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -70,6 +70,7 @@ function logAndDisplayError(error) {
     console.log(error);
     switchToSearch();
     setStatusText(error.message);
+    throw error;
 }
 
 function copyToClipboard(text) {


### PR DESCRIPTION
Since logAndDisplayError does actually not solve the error in the promise chain, we should rethrow the error. Otherwise, we will get call loops like in #104 