### PR TITLE
Add version check, currently for 1.8.5

### DIFF
--- a/tests/unit/generic.test.js
+++ b/tests/unit/generic.test.js
@@ -225,7 +225,7 @@ describe('checkVersion', () => {
         return generic.checkVersion().then(
             () => {},
             error => {
-                expect(error.message).toBe('minimum gopass version is 1.8.5');
+                expect(error.message).toBe('Please update gopass to version 1.8.5 or newer.');
             }
         );
     });

--- a/tests/unit/generic.test.js
+++ b/tests/unit/generic.test.js
@@ -213,3 +213,36 @@ describe('makeAbsolute', () => {
         expect(generic.makeAbsolute('muh.de')).toEqual('https://muh.de');
     });
 });
+
+describe('checkVersion', () => {
+    beforeEach(() => {
+        global.browser.runtime.sendNativeMessage = jest.fn();
+    });
+
+    test('rejects with smaller version', () => {
+        expect.assertions(1);
+        global.browser.runtime.sendNativeMessage.mockResolvedValue({ major: 1, minor: 8, patch: 4 });
+        return generic.checkVersion().then(
+            () => {},
+            error => {
+                expect(error.message).toBe('minimum gopass version is 1.8.5');
+            }
+        );
+    });
+
+    test('resolves with minimum version', () => {
+        expect.assertions(1);
+        global.browser.runtime.sendNativeMessage.mockResolvedValue({ major: 1, minor: 8, patch: 5 });
+        return generic.checkVersion().then(value => {
+            expect(value).toBe(undefined);
+        });
+    });
+
+    test('resolves with larger version', () => {
+        expect.assertions(1);
+        global.browser.runtime.sendNativeMessage.mockResolvedValue({ major: 2, minor: 9, patch: 2 });
+        return generic.checkVersion().then(value => {
+            expect(value).toBe(undefined);
+        });
+    });
+});

--- a/tests/unit/gopassbridge.test.js
+++ b/tests/unit/gopassbridge.test.js
@@ -32,6 +32,8 @@ global.searchHost.mockResolvedValue();
 
 global.logAndDisplayError = jest.fn();
 global.restoreDetailView = jest.fn();
+global.checkVersion = jest.fn();
+global.checkVersion.mockResolvedValue();
 
 require('gopassbridge.js');
 
@@ -90,23 +92,29 @@ describe('switchTab', () => {
     });
 
     test('sends message to mark fields if setting is true', () => {
-        gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' });
-        expect(global.browser.tabs.sendMessage.mock.calls).toEqual([['someid', { type: 'MARK_LOGIN_FIELDS' }]]);
+        expect.assertions(1);
+        return gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' }).then(() => {
+            expect(global.browser.tabs.sendMessage.mock.calls).toEqual([['someid', { type: 'MARK_LOGIN_FIELDS' }]]);
+        });
     });
 
     test('does not send a message to mark fields if setting is false', () => {
         global.executeOnSetting = jest.fn((_, cb) => {});
         global.browser.tabs.sendMessage.mockReset();
-        gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' });
-        expect(global.browser.tabs.sendMessage.mock.calls).toEqual([]);
-        global.executeOnSetting = jest.fn((_, cb) => cb());
+        expect.assertions(1);
+        return gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' }).then(() => {
+            expect(global.browser.tabs.sendMessage.mock.calls).toEqual([]);
+            global.executeOnSetting = jest.fn((_, cb) => cb());
+        });
     });
 
     test('if no search term could be derived, clear results', () => {
         global.urlDomain = jest.fn(() => null);
-        gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' });
-        expect(document.body.innerHTML).not.toEqual(start);
-        global.urlDomain = jest.fn(() => 'some.url');
+        expect.assertions(1);
+        return gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' }).then(() => {
+            expect(document.body.innerHTML).not.toEqual(start);
+            global.urlDomain = jest.fn(() => 'some.url');
+        });
     });
 
     test('if search term could be derived, do not clear results', () => {
@@ -115,8 +123,11 @@ describe('switchTab', () => {
                 <div></div>
             </div>`;
         document.body.innerHTML = start;
-        gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' });
-        expect(document.body.innerHTML).toEqual(start);
+        expect.assertions(1);
+
+        return gopassbridge.switchTab({ url: 'http://some.url', id: 'someid' }).then(() => {
+            expect(document.body.innerHTML).toEqual(start);
+        });
     });
 
     test('if search term in local storage, call search', () => {

--- a/web-extension/generic.js
+++ b/web-extension/generic.js
@@ -33,7 +33,9 @@ function checkVersion() {
             return Promise.resolve();
         }
         console.log('Version is not OK');
-        return Promise.reject(new Error(`minimum gopass version is ${REQUIRED_GOPASS_VERSION.join('.')}`));
+        return Promise.reject(
+            new Error(`Please update gopass to version ${REQUIRED_GOPASS_VERSION.join('.')} or newer.`)
+        );
     });
 }
 

--- a/web-extension/generic.js
+++ b/web-extension/generic.js
@@ -10,6 +10,31 @@ const DEFAULT_SETTINGS = {
 
 const LAST_DOMAIN_SEARCH_PREFIX = 'LAST_DOMAIN_SEARCH_';
 const LAST_DETAIL_VIEW_PREFIX = 'LAST_DETAIL_VIEW_';
+const REQUIRED_GOPASS_VERSION = [1, 8, 5];
+
+let versionOK = undefined;
+
+function checkVersion() {
+    if (versionOK) {
+        return Promise.resolve();
+    }
+
+    return sendNativeAppMessage({ type: 'getVersion' }).then(response => {
+        let major = REQUIRED_GOPASS_VERSION[0];
+        let minor = REQUIRED_GOPASS_VERSION[1];
+        let patch = REQUIRED_GOPASS_VERSION[2];
+        if (
+            response.major > major ||
+            (response.major === major && (response.minor > minor || response.minor === minor && response.patch >= patch)
+        )) {
+            versionOK = true;
+            console.log('Version is OK');
+            return Promise.resolve();
+        }
+        console.log('Version is not OK');
+        return Promise.reject(new Error(`minimum gopass version is ${REQUIRED_GOPASS_VERSION.join('.')}`));
+    });
+}
 
 const URL_PATTERN = /^https?:\/\//i;
 
@@ -116,5 +141,6 @@ window.tests = {
         isChrome,
         openURLOnEvent,
         makeAbsolute,
+        checkVersion,
     },
 };

--- a/web-extension/generic.js
+++ b/web-extension/generic.js
@@ -25,8 +25,9 @@ function checkVersion() {
         let patch = REQUIRED_GOPASS_VERSION[2];
         if (
             response.major > major ||
-            (response.major === major && (response.minor > minor || response.minor === minor && response.patch >= patch)
-        )) {
+            (response.major === major &&
+                (response.minor > minor || (response.minor === minor && response.patch >= patch)))
+        ) {
             versionOK = true;
             console.log('Version is OK');
             return Promise.resolve();


### PR DESCRIPTION
Version check, can be used by other features to ensure minimum gopass version