### PR TITLE
Fix detail view nesting with lists (related to #114)

### DIFF
--- a/tests/unit/details.test.js
+++ b/tests/unit/details.test.js
@@ -88,12 +88,24 @@ describe('onEntryData', () => {
         });
 
         test('nested values', () => {
-            expect.assertions(3);
-            return details.onEntryData(loginElement, { hallo: { holla: 'waldfee' } }).then(() => {
-                expect(document.getElementsByClassName('detail-key')[0].innerText).toBe('hallo:');
-                expect(document.getElementsByClassName('detail-key')[1].innerText).toBe('holla:');
-                expect(document.getElementsByClassName('detail-clickable-value')[0].innerText).toBe('waldfee');
-            });
+            expect.assertions(9);
+            return details
+                .onEntryData(loginElement, { hallo: { holla: 'waldfee', list: ['wald', 'fee'] } })
+                .then(() => {
+                    let keys = document.getElementsByClassName('detail-key');
+                    expect(keys.length).toBe(3);
+                    expect(keys[0].innerText).toBe('hallo:');
+                    expect(keys[1].innerText).toBe('holla:');
+                    expect(keys[2].innerText).toBe('list:');
+
+                    let values = document.getElementsByClassName('detail-clickable-value');
+                    expect(values.length).toBe(3);
+                    expect(values[0].innerText).toBe('waldfee');
+                    expect(values[1].innerText).toBe('wald');
+                    expect(values[2].innerText).toBe('fee');
+
+                    expect(document.getElementsByClassName('detail-nested').length).toBe(2);
+                });
         });
     });
 

--- a/web-extension/details.js
+++ b/web-extension/details.js
@@ -25,7 +25,7 @@ function _insertAfter(newNode, referenceNode) {
 }
 
 function _detailViewFromMessage(message) {
-    const container = document.createElement('div');
+    const container = document.createElement('ul');
     Object.keys(message)
         .filter(key => message[key] !== null && message[key] !== undefined && message[key] !== '')
         .forEach(key => _appendEntry(container, key, message[key]));
@@ -33,9 +33,13 @@ function _detailViewFromMessage(message) {
 }
 
 function _createNestedValueElement(value) {
-    const valueElement = document.createElement('div');
+    const valueElement = document.createElement('ul');
     valueElement.classList.add('detail-nested');
-    Object.keys(value).forEach(key => _appendEntry(valueElement, key, value[key]));
+    if (Array.isArray(value)) {
+        value.forEach(item => _appendEntry(valueElement, null, item));
+    } else {
+        Object.keys(value).forEach(key => _appendEntry(valueElement, key, value[key]));
+    }
     return valueElement;
 }
 
@@ -70,15 +74,18 @@ function _createFlatValueElement(value) {
 }
 
 function _appendEntry(container, key, value) {
-    let keyElement, valueElement;
     const entryElement = document.createElement('li');
+    let hasKey = key !== undefined && key !== null;
 
-    keyElement = document.createElement('span');
-    keyElement.innerText = `${key}:`;
-    keyElement.classList.add('detail-key');
-    valueElement = _isNested(value) ? _createNestedValueElement(value) : _createFlatValueElement(value);
+    if (hasKey) {
+        let keyElement = document.createElement('span');
+        keyElement.innerText = `${key}:`;
+        keyElement.classList.add('detail-key');
+        entryElement.appendChild(keyElement);
+    }
 
-    entryElement.appendChild(keyElement);
+    let valueElement = _isNested(value) ? _createNestedValueElement(value) : _createFlatValueElement(value);
+
     entryElement.appendChild(valueElement);
     container.appendChild(entryElement);
 }

--- a/web-extension/styles.css
+++ b/web-extension/styles.css
@@ -85,8 +85,7 @@ body {
 }
 
 .detail-nested {
-    display: inline;
-    padding: 10px 7px 10px 7px;
+    padding-left: 16px;
 }
 
 .login:last-of-type {


### PR DESCRIPTION
(this is related to #114)

Correctly handle lists and use browser-native list nesting as recommended here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul

Here is how it looked before my changes (Chrome left, Firefox right)
<img width="1299" alt="before_broken_chrome_left_firefox_right" src="https://user-images.githubusercontent.com/7095678/62838479-10c83180-bc7d-11e9-98c0-a911e36debab.png">

Here is how it looks with these changes (Chrome left, Firefox right)
<img width="1374" alt="after_fixed_chrome_left_firefox_right" src="https://user-images.githubusercontent.com/7095678/62838482-158ce580-bc7d-11e9-9f13-c17f8bea646a.png">

I used this gopass entry in the screenshots:
```yaml
a_long_random_password
---
url: www.github.com
email: abc@gmail.com
totp: otpauth://totp/GitHub:test?secret=1234123412341234&issuerGitHub

recovery codes:
- abcde-12345
- fghij-67890
- zyxwv-05432
- test1:
  - alksdfj
  - alksdfjalsf
  - ["bla", "blub"]
  - test2:
    - alksd
    - aklsdjf
    - sfd
- last code here!
dict:
 dict1:
  dict1.1: 1.1
  dict1.2: 1.2
 dict2:
  dict2.1:
    dict2.1.1: one
    dict2.1.2: two
 dict3: 0
```