### PR TITLE
append login to name

### DIFF
--- a/tests/unit/create.test.js
+++ b/tests/unit/create.test.js
@@ -5,6 +5,8 @@ const fs = require('fs');
 global.armSpinnerTimeout = jest.fn();
 global.sendNativeAppMessage = jest.fn();
 global.sendNativeAppMessage.mockResolvedValue({});
+global.getSettings = jest.fn();
+global.getSettings.mockResolvedValue({ appendlogintoname: true });
 global.switchToSearch = jest.fn();
 global.setStatusText = jest.fn();
 global.urlDomain = jest.fn(() => 'some.domain');
@@ -59,7 +61,7 @@ describe('create', () => {
             expect(global.sendNativeAppMessage.mock.calls).toEqual([
                 [
                     {
-                        entry_name: '',
+                        entry_name: '/',
                         generate: true,
                         length: 24,
                         login: '',
@@ -72,9 +74,10 @@ describe('create', () => {
         });
 
         test('starts query after successful finishing', () => {
-            expect.assertions(1);
+            expect.assertions(2);
             promise.then(() => {
                 expect(global.searchHost).toHaveBeenCalledTimes(1);
+                expect(global.getSettings).toHaveBeenCalledTimes(4);
             });
         });
     });

--- a/web-extension/_locales/de/messages.json
+++ b/web-extension/_locales/de/messages.json
@@ -117,7 +117,7 @@
     "description": "label of send notifications checkbox"
   },
   "optionsAppendToLoginName": {
-    "message": "Append login/username to password path on creation",
+    "message": "Hänge Login/Benutzername an den Passwortpfad beim Erzeugen an",
     "description" : "label of append login to password path checkbox"
   },
   "optionsLoginAfterFillLabel": {

--- a/web-extension/_locales/de/messages.json
+++ b/web-extension/_locales/de/messages.json
@@ -116,6 +116,10 @@
     "message": "Erlaube Benachrichtigungen anzuzeigen falls nötig",
     "description": "label of send notifications checkbox"
   },
+  "optionsAppendToLoginName": {
+    "message": "Append login/username to password path on creation",
+    "description" : "label of append login to password path checkbox"
+  },
   "optionsLoginAfterFillLabel": {
     "message": "Einloggen wenn Logindaten ausgefüllt wurden",
     "description": "label of login after fill checkbox"

--- a/web-extension/_locales/en/messages.json
+++ b/web-extension/_locales/en/messages.json
@@ -116,6 +116,10 @@
     "message": "Allow to send notifications if necessary",
     "description": "label of send notifications checkbox"
   },
+  "optionsAppendToLoginName": {
+    "message": "Append login/username to password path on creation",
+    "description" : "label of append login to password path checkbox"
+  },
   "optionsLoginAfterFillLabel": {
     "message": "Login after filling in credentials",
     "description": "label of login after fill checkbox"

--- a/web-extension/create.js
+++ b/web-extension/create.js
@@ -8,7 +8,7 @@ function initCreate() {
 
 function onDoCreate(event) {
     event.preventDefault();
-    getSettings().then(settings => {
+    return getSettings().then(settings => {
         let name = document.getElementById('create_name').value;
         if (settings['appendlogintoname']) {
             name = name + '/' + document.getElementById('create_login').value;

--- a/web-extension/create.js
+++ b/web-extension/create.js
@@ -8,20 +8,26 @@ function initCreate() {
 
 function onDoCreate(event) {
     event.preventDefault();
-    const message = {
-        type: 'create',
-        entry_name: document.getElementById('create_name').value,
-        login: document.getElementById('create_login').value,
-        password: document.getElementById('create_password').value,
-        length: Number(document.getElementById('create_generate_length').value),
-        generate: document.getElementById('create_generate').checked,
-        use_symbols: document.getElementById('create_use_symbols').checked,
-    };
-    armSpinnerTimeout();
-    document.getElementById('create_docreate').style.display = 'none';
-    document.getElementById('create_doabort').style.display = 'none';
-    document.getElementById('creating').style.display = 'block';
-    return sendNativeAppMessage(message).then(onCreateResult, logAndDisplayError);
+    getSettings().then(settings => {
+        let name = document.getElementById('create_name').value;
+        if (settings['appendlogintoname']) {
+            name = name + '/' + document.getElementById('create_login').value;
+        }
+        const message = {
+            type: 'create',
+            entry_name: name,
+            login: document.getElementById('create_login').value,
+            password: document.getElementById('create_password').value,
+            length: Number(document.getElementById('create_generate_length').value),
+            generate: document.getElementById('create_generate').checked,
+            use_symbols: document.getElementById('create_use_symbols').checked,
+        };
+        armSpinnerTimeout();
+        document.getElementById('create_docreate').style.display = 'none';
+        document.getElementById('create_doabort').style.display = 'none';
+        document.getElementById('creating').style.display = 'block';
+        return sendNativeAppMessage(message).then(onCreateResult, logAndDisplayError);
+    });
 }
 
 function onDoAbort() {

--- a/web-extension/generic.js
+++ b/web-extension/generic.js
@@ -8,6 +8,7 @@ const DEFAULT_SETTINGS = {
     defaultfolder: 'Account',
     omitkeys: 'otpauth',
     defaultpasswordlength: 24,
+    appendlogintoname: false,
 };
 
 const LAST_DOMAIN_SEARCH_PREFIX = 'LAST_DOMAIN_SEARCH_';

--- a/web-extension/options.html
+++ b/web-extension/options.html
@@ -20,6 +20,7 @@
     <label><input type="checkbox" id="sendnotifications"/> __MSG_optionsSendNotificationsLabel__</label>
     <label><input type="checkbox" id="submitafterfill"/> __MSG_optionsLoginAfterFillLabel__</label>
     <label><input type="checkbox" id="handleauthrequests"/> __MSG_optionsHandleAuthRequestsLabel__</label>
+    <label><input type="checkbox" id="appendlogintoname"/> __MSG_optionsAppendToLoginName__</label>
     <label>__MSG_optionsDefaultFolderLabel__ <input type="text" id="defaultfolder"/></label>
     <label>__MSG_optionsOmitKeysLabel__ <input type="text" id="omitkeys"/></label>
     <label>__MSG_optionsDefaultPasswordLengthLabel__ <input type="text" id="defaultpasswordlength"/></label>


### PR DESCRIPTION
Hello,
This is a simple commit adding an option to append the login to the password path. Useful if you naming scheme is website.com/login (which allows to have several account for the same website in a single repository).
The german translation of the option description is missing.