### PR TITLE
Improve error handling in preparation of gopass 1.10

### DIFF
--- a/web-extension/_locales/de/messages.json
+++ b/web-extension/_locales/de/messages.json
@@ -173,7 +173,7 @@
     "description": "Error when another basic authentication popup is already open"
   },
   "correctlySetup": {
-    "message": "Ist Gopass für Gopass Bridge eingerichtet?",
+    "message": "Ist Gopass für Gopass Bridge eingerichtet? Bei Aktualisierung auf Gopass v1.10 oder neuer muss das gopass-jsonapi Setup erneut ausgeführt werden.",
     "description": "Error when gopassbridge is not correctly setup"
   }
 }

--- a/web-extension/_locales/en/messages.json
+++ b/web-extension/_locales/en/messages.json
@@ -173,7 +173,7 @@
     "description": "Error when another basic authentication popup is already open"
   },
   "correctlySetup": {
-    "message": "Is your browser correctly set up for gopass?",
+    "message": "Is your browser correctly set up for gopass? If you are upgrading to gopass v1.10 or newer you need to re-run the gopass-jsonapi setup command.",
     "description": "Error when gopassbridge is not correctly setup"
   }
 }

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -7,7 +7,9 @@ const SETUP_ERRORS = [
     'Attempt to postMessage on disconnected port',
     'Specified native messaging host not found',
     'Native host has exited', // Chrome: gopass-jsonapi not found or other error in gopass_wrapper.sh
+    'Error when communicating with the native messaging host', // Chrome: gopass v1.10 returns invalid message
     'An unexpected error occurred', // Firefox: gopass-jsonapi not found or other error in gopass_wrapper.sh
+    'Native application tried to send a message', // Firefox: gopass v1.10 returns invalid message
 ];
 
 function armSpinnerTimeout() {

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -6,6 +6,8 @@ const SETUP_ERRORS = [
     'Access to the specified native messaging host is forbidden',
     'Attempt to postMessage on disconnected port',
     'Specified native messaging host not found',
+    'Native host has exited', // Chrome: gopass-jsonapi not found or other error in gopass_wrapper.sh
+    'An unexpected error occurred', // Firefox: gopass-jsonapi not found or other error in gopass_wrapper.sh
 ];
 
 function armSpinnerTimeout() {

--- a/web-extension/styles.css
+++ b/web-extension/styles.css
@@ -23,6 +23,7 @@ body {
 .status-text {
     padding: 6px;
     text-align: center;
+    max-width: 400px;
 }
 
 .results {


### PR DESCRIPTION
RELEASE_NOTES=Improve error handling for gopass 1.10 upgrade

<img width="416" alt="Screenshot 2020-08-09 at 23 52 32" src="https://user-images.githubusercontent.com/7095678/89742901-5f7df680-da9e-11ea-91d9-24a3ce5789ab.png">

![Screenshot 2020-08-09 at 23 06 20](https://user-images.githubusercontent.com/7095678/89742905-63aa1400-da9e-11ea-9ef5-7fb7d62eea03.png)

![Screenshot 2020-08-11 at 00 28 30](https://user-images.githubusercontent.com/7095678/89837826-0a0f1b80-db6a-11ea-8ca3-acef7d2299ae.png)

<img width="413" alt="Screenshot 2020-08-11 at 00 28 36" src="https://user-images.githubusercontent.com/7095678/89837831-0da2a280-db6a-11ea-90aa-aa93e51281fb.png">

Handle:
- Native host has exited
- Error when communicating with the native messaging host
- An unexpected error occurred (=> strange Firefox behaviour, probably broken in the browser?)
- Native application tried to send a message...