### PR TITLE
Option to create new credentials against an already-saved site

### DIFF
--- a/tests/unit/search.test.js
+++ b/tests/unit/search.test.js
@@ -257,6 +257,13 @@ describe('search method', () => {
                             },
                             expect.any(Function),
                         ],
+                        [
+                            {
+                                className: 'login',
+                                textContent: '__KEY_createAnotherEntryButtonText__',
+                            },
+                            expect.any(Function),
+                        ],
                     ]);
 
                     expect(global.sendNativeAppMessage.mock.calls).toEqual([[{ host: 'mih', type: 'queryHost' }]]);

--- a/web-extension/_locales/de/messages.json
+++ b/web-extension/_locales/de/messages.json
@@ -12,7 +12,7 @@
     "description": "Text of create new entry button"
   },
   "createAnotherEntryButtonText": {
-    "message": "sie einen weiteren Eintrag erstellen",
+    "message": "einen weiteren Eintrag erstellen",
     "description": "Text of create another entry button"
   },
   "copiedToClipboardMessage": {

--- a/web-extension/_locales/de/messages.json
+++ b/web-extension/_locales/de/messages.json
@@ -11,6 +11,10 @@
     "message": "neuen Eintrag erstellen",
     "description": "Text of create new entry button"
   },
+  "createAnotherEntryButtonText": {
+    "message": "sie einen weiteren Eintrag erstellen",
+    "description": "Text of create another entry button"
+  },
   "copiedToClipboardMessage": {
     "message": "kopiert in die Zwischenablage",
     "description": "Text to display when an entry was copied to clipboard"

--- a/web-extension/_locales/en/messages.json
+++ b/web-extension/_locales/en/messages.json
@@ -11,6 +11,10 @@
     "message": "create new login entry",
     "description": "Text of create new entry button"
   },
+  "createAnotherEntryButtonText": {
+    "message": "create another login entry",
+    "description": "Text of create another entry button"
+  },
   "copiedToClipboardMessage": {
     "message": "copied to clipboard",
     "description": "Text to display when an entry was copied to clipboard"

--- a/web-extension/search.js
+++ b/web-extension/search.js
@@ -127,16 +127,17 @@ function _displaySearchResults(response, isHostQuery) {
         results.appendChild(entry);
     });
 
-    results.appendChild(
-        createButtonWithCallback(
-            {
-                className: 'login',
-                textContent: i18n.getMessage('createAnotherEntryButtonText'),
-            },
-            switchToCreateNewDialog
-        )
-    );
+    results.appendChild(_createAnotherEntryButton());
 }
+
+const _createAnotherEntryButton = () =>
+    createButtonWithCallback(
+        {
+            className: 'login',
+            textContent: i18n.getMessage('createAnotherEntryButtonText'),
+        },
+        switchToCreateNewDialog
+    );
 
 const _createSearchResultLoginButton = (item, isHostQuery) =>
     createButtonWithCallback(

--- a/web-extension/search.js
+++ b/web-extension/search.js
@@ -126,6 +126,16 @@ function _displaySearchResults(response, isHostQuery) {
 
         results.appendChild(entry);
     });
+
+    results.appendChild(
+        createButtonWithCallback(
+            {
+                className: 'login',
+                textContent: i18n.getMessage('createAnotherEntryButtonText'),
+            },
+            switchToCreateNewDialog
+        )
+    );
 }
 
 const _createSearchResultLoginButton = (item, isHostQuery) =>


### PR DESCRIPTION

RELEASE_NOTES=Show option of "create another login entry" for a site which already has credentials saved

I (and many people might have) felt such a need to have multiple credentials against a single site. Current workaround for me is to goto the command line -> `gopass generate`. Nice to have feature 🙂