### PR TITLE
Run entry action on first result when pressing return key.

### DIFF
--- a/web-extension/search.js
+++ b/web-extension/search.js
@@ -16,7 +16,7 @@ function initSearch() {
 function _onSearchKeypressEvent(event) {
     if (event.keyCode === 13) {
         const elements = document.getElementsByClassName('login');
-        if (elements.length === 1) {
+        if (elements.length >= 1) {
             _onEntryAction(event, elements[0]);
         }
         event.preventDefault();


### PR DESCRIPTION
Checking if elements contains at least one element should be enough to ensure safe behavior.

In this way, the first element can always be selected using the return key.

Fixes #219