### PR TITLE
Select first entry even if create login is shown, closes #219

### DIFF
--- a/tests/unit/search.test.js
+++ b/tests/unit/search.test.js
@@ -259,7 +259,7 @@ describe('search method', () => {
                         ],
                         [
                             {
-                                className: 'login',
+                                className: 'login createlogin',
                                 textContent: '__KEY_createAnotherEntryButtonText__',
                             },
                             expect.any(Function),
@@ -456,7 +456,7 @@ describe('search input', () => {
             addDummySearchResult();
             addDummySearchResult();
             const event = simulateKeyPress({ keyCode: 13 });
-            expect(global.browser.tabs.sendMessage.mock.calls.length).toBe(0);
+            expect(global.browser.runtime.sendMessage.mock.calls.length).toBe(0);
             expect(event.preventDefault.mock.calls.length).toBe(1);
         });
 

--- a/web-extension/search.js
+++ b/web-extension/search.js
@@ -15,9 +15,10 @@ function initSearch() {
 
 function _onSearchKeypressEvent(event) {
     if (event.keyCode === 13) {
-        const elements = document.getElementsByClassName('login');
-        if (elements.length === 1) {
-            _onEntryAction(event, elements[0]);
+        const logins = document.getElementsByClassName('login');
+        const creates = document.getElementsByClassName('createlogin');
+        if (logins.length - creates.length === 1) {
+            _onEntryAction(event, logins[0]);
         }
         event.preventDefault();
     }
@@ -133,7 +134,7 @@ function _displaySearchResults(response, isHostQuery) {
 const _createAnotherEntryButton = () =>
     createButtonWithCallback(
         {
-            className: 'login',
+            className: 'login createlogin',
             textContent: i18n.getMessage('createAnotherEntryButtonText'),
         },
         switchToCreateNewDialog


### PR DESCRIPTION
@tompre I've tried a slightly different approach that specifically selects the first entry (and ignores the create login).