### PR TITLE
Skip codecov upload for PRs from forks

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Upload coverage to Codecov
         # Docs: https://github.com/marketplace/actions/codecov
         uses: codecov/codecov-action@v4
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
(e.g. dependabot)