### PR TITLE
Update firefox-manifest to resolve warnings

### DIFF
--- a/manifests/firefox-manifest.json
+++ b/manifests/firefox-manifest.json
@@ -14,10 +14,10 @@
     "96": "icons/gopassbridge-96.png"
   },
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "{eec37db0-22ad-4bf1-9068-5ae08df8c7e9}",
-      "strict_min_version": "60.0"
+      "strict_min_version": "79.0"
     }
   },
 


### PR DESCRIPTION
Fixes:
```
Code                              Message                                       Description                                                                                     File
APPLICATIONS_DEPRECATED           Use "browser_specific_settings" instead of    The "applications" property in the manifest is deprecated and will no longer be accepted in     manifest.json
                                  "applications".                               Manifest Version 3 and above.
KEY_FIREFOX_ANDROID_UNSUPPORTE…   Manifest key not supported by the specified   "strict_min_version" requires Firefox for Android 60, which was released before version 79      manifest.json
```