### PR TITLE
Migrate Chrome extension to Manifest V3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ release: package
 		$(LOCAL_WEB_EXT) -s $(CURDIR)/firefox-release build --overwrite-dest
 
 clean:
-		rm -rf chrome firefox chrome-release firefox-release chrome.zip webextension-polyfill
+		rm -rf chrome firefox chrome-release firefox-release chrome.zip webextension-polyfill web-ext-artifacts
 
 format:
 		npm run format

--- a/manifests/chrome-manifest-dev.json
+++ b/manifests/chrome-manifest-dev.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "short_name": "gopassbridge",
   "name": "Gopass Bridge",
   "version": "1.0.0",
@@ -27,14 +27,10 @@
     }
   ],
 
+  "minimum_chrome_version": "88",
+
   "background": {
-    "scripts": [
-      "vendor/browser-polyfill.js",
-      "generic.js",
-      "i18n.js",
-      "background.js"
-    ],
-    "persistent": true
+    "service_worker": "service_worker.js"
   },
 
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0mHC1MVxHG3X9CZ6b6lp1hCW5j2nP9bRES/Mw6sL1Emkp6HyHXU745HRGv+JD8Q+jvo85IYjGnxrcrgq+K9Op8S4ggzjaZMVL9kmDeluQPRE4247uEu2WCLZR7x00A2unZtErvlwNYiYIRcqhDZ5VQDtxKNdg6CsFr56g7ur2iuF4+RwKSDbdfVY0t9yb++Rsj9aAtarDbPnuR4gWDzR/3AL4SmgU21BQYARjUQHLFmmH1M2YWVz2I9Z3w2m3EfL6oNMSm7qFweRTrBMmVKLwQ9jitvz8To7QX5si6y8L3CRKBNtBIwBF3t8Cm4CIB5Tfjh/6RN5cf/9D7Jci0EXOQIDAQAB",
@@ -45,7 +41,7 @@
 
   "default_locale": "en",
 
-  "browser_action": {
+  "action": {
     "browser_style": true,
     "default_icon": {
       "48": "icons/gopassbridge-48.png",
@@ -56,9 +52,10 @@
   },
 
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
-        "default": "Ctrl+Shift+U"
+        "default": "Ctrl+Shift+U",
+        "mac": "Command+Shift+U"
       }
     }
   },
@@ -67,10 +64,17 @@
     "activeTab",
     "storage",
     "nativeMessaging",
-    "http://*/*",
-    "https://*/*",
     "notifications",
     "webRequest",
-    "webRequestBlocking"
-  ]
+    "webRequestAuthProvider"
+  ],
+
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
+
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; style-src 'unsafe-inline';"
+  }
 }

--- a/manifests/chrome-manifest.json
+++ b/manifests/chrome-manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "short_name": "gopassbridge",
   "name": "Gopass Bridge",
   "version": "1.0.0",
@@ -27,16 +27,10 @@
     }
   ],
 
-  "minimum_chrome_version": "63",
+  "minimum_chrome_version": "88",
 
   "background": {
-    "scripts": [
-      "vendor/browser-polyfill.js",
-      "generic.js",
-      "i18n.js",
-      "background.js"
-    ],
-    "persistent": true
+    "service_worker": "service_worker.js"
   },
 
   "options_ui": {
@@ -45,7 +39,7 @@
 
   "default_locale": "en",
 
-  "browser_action": {
+  "action": {
     "browser_style": true,
     "default_icon": {
       "48": "icons/gopassbridge-48.png",
@@ -56,9 +50,10 @@
   },
 
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
-        "default": "Ctrl+Shift+U"
+        "default": "Ctrl+Shift+U",
+        "mac": "Command+Shift+U"
       }
     }
   },
@@ -67,10 +62,17 @@
     "activeTab",
     "storage",
     "nativeMessaging",
-    "http://*/*",
-    "https://*/*",
     "notifications",
     "webRequest",
-    "webRequestBlocking"
-  ]
+    "webRequestAuthProvider"
+  ],
+
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
+
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; style-src 'unsafe-inline';"
+  }
 }

--- a/tests/unit/generic.test.js
+++ b/tests/unit/generic.test.js
@@ -102,6 +102,10 @@ describe('urlDomain', () => {
     test('extracts hostname', () => {
         expect(generic.urlDomain('http://www.muh.maeh.de:80/some/path?maeh')).toEqual('www.muh.maeh.de');
     });
+
+    test('extracts default "localhost" for invalid URL', () => {
+        expect(generic.urlDomain('invalid')).toEqual('localhost');
+    });
 });
 
 describe('localStorage wrappers', () => {

--- a/web-extension/background.js
+++ b/web-extension/background.js
@@ -224,9 +224,11 @@ function initBackground() {
 
 initBackground();
 
-window.tests = {
-    background: {
-        initBackground,
-        processMessageAndCatch,
-    },
-};
+if ('window' in globalThis) {
+    window.tests = {
+        background: {
+            initBackground,
+            processMessageAndCatch,
+        },
+    };
+}

--- a/web-extension/generic.js
+++ b/web-extension/generic.js
@@ -94,9 +94,11 @@ function createButtonWithCallback(attributes, callback) {
 }
 
 function urlDomain(urlString) {
-    const a = document.createElement('a');
-    a.href = urlString;
-    return a.hostname;
+    try {
+        return new URL(urlString).hostname;
+    } catch (e) {
+        return 'localhost';
+    }
 }
 
 function setLocalStorageKey(key, value) {
@@ -132,19 +134,21 @@ function isChrome() {
     return browser.runtime.getURL('/').startsWith('chrome');
 }
 
-window.tests = {
-    generic: {
-        sendNativeAppMessage,
-        executeOnSetting,
-        urlDomain,
-        setLocalStorageKey,
-        getLocalStorageKey,
-        createButtonWithCallback,
-        showNotificationOnSetting,
-        getPopupUrl,
-        isChrome,
-        openURLOnEvent,
-        makeAbsolute,
-        checkVersion,
-    },
-};
+if ('window' in globalThis) {
+    window.tests = {
+        generic: {
+            sendNativeAppMessage,
+            executeOnSetting,
+            urlDomain,
+            setLocalStorageKey,
+            getLocalStorageKey,
+            createButtonWithCallback,
+            showNotificationOnSetting,
+            getPopupUrl,
+            isChrome,
+            openURLOnEvent,
+            makeAbsolute,
+            checkVersion,
+        },
+    };
+}

--- a/web-extension/service_worker.js
+++ b/web-extension/service_worker.js
@@ -1,0 +1,5 @@
+'use strict';
+
+importScripts('vendor/browser-polyfill.js');
+importScripts('generic.js');
+importScripts('background.js');


### PR DESCRIPTION
Notes:

- "suggested_key" auto-conversion of "Ctrl" to "Command" on Mac does not work as documented by MDN / Chromium (I suspect this is a bug in Chromium, workaround is simple enough)
- service worker does not follow current best practises regarding storage and timers (good enough for now, can be further improved)