### PR TITLE
fix: Test failure getting swallowed because promise not returned.

### DIFF
--- a/tests/unit/create.test.js
+++ b/tests/unit/create.test.js
@@ -70,9 +70,9 @@ describe('create', () => {
 
         test('starts query after successful finishing', () => {
             expect.assertions(2);
-            promise.then(() => {
+            return promise.then(() => {
                 expect(global.searchHost).toHaveBeenCalledTimes(1);
-                expect(global.getSettings).toHaveBeenCalledTimes(4);
+                expect(global.getSettings).toHaveBeenCalledTimes(1);
             });
         });
     });


### PR DESCRIPTION
Return the promise from the test so it works properly. Was failing but reporting as passing.

I looked at the code and I also changed the assert, because it looks to me like `getSettings` is only called once in `onDoCreate`. So the test passes now. If that assumption is incorrect please lmk.