### PR TITLE
feat: add copy username button to search results

### DIFF
--- a/tests/unit/search.test.mjs
+++ b/tests/unit/search.test.mjs
@@ -205,6 +205,14 @@ describe('search method', () => {
                     ],
                     [
                         {
+                            className: 'copy_username',
+                            textContent: 'some/entry',
+                            title: '__translated_searchResultCopyUsernameTooltip__',
+                        },
+                        expect.any(Function),
+                    ],
+                    [
+                        {
                             className: 'details',
                             textContent: 'some/entry',
                             title: '__translated_searchResultDetailsTooltip__',
@@ -254,7 +262,7 @@ describe('search method', () => {
                 sendNativeAppMessage.mockResolvedValueOnce(['some/entry']);
                 await search.searchHost('mih');
                 sendNativeAppMessage.mockClear();
-                createButtonWithCallback.mock.calls[3][1]({
+                createButtonWithCallback.mock.calls[4][1]({
                     target: { innerText: 'text' },
                 });
                 expect(sendNativeAppMessage.mock.calls).toEqual([[{ entry: 'text', type: 'getData' }]]);

--- a/web-extension/_locales/de/messages.json
+++ b/web-extension/_locales/de/messages.json
@@ -51,6 +51,10 @@
     "message": "Kopieren",
     "description": "tooltip for copy button in search result"
   },
+  "searchResultCopyUsernameTooltip": {
+    "message": "Benutzername kopieren",
+    "description": "tooltip for copy username button in search result"
+  },
   "searchResultDetailsTooltip": {
     "message": "Details anzeigen",
     "description": "tooltip for details button in search result"

--- a/web-extension/_locales/en/messages.json
+++ b/web-extension/_locales/en/messages.json
@@ -51,6 +51,10 @@
     "message": "Copy",
     "description": "tooltip for copy button in search result"
   },
+  "searchResultCopyUsernameTooltip": {
+    "message": "Copy username",
+    "description": "tooltip for copy username button in search result"
+  },
   "searchResultDetailsTooltip": {
     "message": "Show details",
     "description": "tooltip for details button in search result"

--- a/web-extension/icons/si-glyph-person.svg
+++ b/web-extension/icons/si-glyph-person.svg
@@ -1,0 +1,13 @@
+<!--?xml version="1.0" encoding="UTF-8" standalone="no"?-->
+<svg viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="si-glyph si-glyph-person">
+    <!-- Generator: Sketch 3.0.3 (7891) - http://www.bohemiancoding.com/sketch -->
+    <title>866</title>
+    
+    <defs></defs>
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(1.000000, 1.000000)" fill="#434343">
+            <path d="M11.518,9 C11.116,9.548 10.619,10.62 10.039,11.593 C9.402,12.667 8.672,9.994 7.873,9.994 C7.052,9.994 6.285,12.618 5.621,11.518 C5.049,10.571 4.555,9.551 4.165,9.027 C0.122,9.027 0,14.914 0,14.914 L15.745,14.914 C15.745,14.915 16.063,9 11.518,9 L11.518,9 Z" class="si-glyph-fill"></path>
+            <path d="M10.895,3.3720005 C10.895,5.2330005 9.577,8.7940005 7.947,8.7940005 C6.319,8.7940005 5,5.2330005 5,3.3720005 C5,1.5090005 6.319,4.96730683e-07 7.947,4.96730683e-07 C9.577,-0.000999503269 10.895,1.5080005 10.895,3.3720005 L10.895,3.3720005 Z" class="si-glyph-fill"></path>
+        </g>
+    </g>
+</svg>

--- a/web-extension/search.js
+++ b/web-extension/search.js
@@ -118,6 +118,14 @@ function _displaySearchResults(response, isHostQuery) {
         );
         entry.appendChild(
             _createSimpleSearchResultButton(
+                'copy_username',
+                item,
+                i18n.getMessage('searchResultCopyUsernameTooltip'),
+                _onEntryCopyUsername
+            )
+        );
+        entry.appendChild(
+            _createSimpleSearchResultButton(
                 'details',
                 item,
                 i18n.getMessage('searchResultDetailsTooltip'),
@@ -213,6 +221,22 @@ function _onEntryCopy(element) {
     );
 }
 
+function _onEntryCopyUsername(element) {
+    sendNativeAppMessage({ type: 'getLogin', entry: element.innerText }).then((response) => {
+        if (response.error) {
+            setStatusText(response.error);
+            return;
+        }
+        if (!response.username) {
+            setStatusText(i18n.getMessage('couldNotDetermineUsernameMessage'));
+            return;
+        }
+        navigator.clipboard
+            .writeText(response.username)
+            .then(() => _onLoginCredentialsDoCopyClipboard({}), logAndDisplayError);
+    }, logAndDisplayError);
+}
+
 function _onEntryOpen(element) {
     browser.runtime
         .sendMessage({ type: 'OPEN_TAB', entry: element.innerText })
@@ -256,5 +280,6 @@ try {
         searchHost,
         _onEntryAction,
         _onSearchResults,
+        _onEntryCopyUsername,
     };
 } catch (_) {}

--- a/web-extension/styles.css
+++ b/web-extension/styles.css
@@ -126,6 +126,7 @@ input {
 }
 
 .entry .copy,
+.entry .copy_username,
 .entry .open,
 .entry .details {
     display: none;
@@ -153,18 +154,25 @@ input {
     background-image: url('icons/si-glyph-document-copy.svg');
 }
 
-.entry .open {
+.entry .copy_username {
     right: 65px;
+    background-image: url('icons/si-glyph-person.svg');
+}
+
+.entry .open {
+    right: 95px;
     background-image: url('icons/si-glyph-arrow-forward.svg');
 }
 
 .entry:hover .copy,
+.entry:hover .copy_username,
 .entry:hover .open,
 .entry:hover .details {
     display: block;
 }
 
 .entry .copy:hover,
+.entry .copy_username:hover,
 .entry .open:hover,
 .entry .details:hover {
     opacity: 0.6;
@@ -173,6 +181,7 @@ input {
 }
 
 .entry .copy:active,
+.entry .copy_username:active,
 .entry .open:active,
 .entry .details:active {
     opacity: 0.6;


### PR DESCRIPTION
Add a dedicated button to copy the username to clipboard, making it easier to handle two-step login flows where username and password are entered on separate pages.